### PR TITLE
Update offcanvas.css

### DIFF
--- a/WebContent/css/offcanvas.css
+++ b/WebContent/css/offcanvas.css
@@ -111,6 +111,7 @@ footer {
 
 .rightPanel {
 	overflow: auto;
+	height: 100% !important; /* to make overflow-y possible on all screen sizes */
 }
 
 .swc-main {


### PR DESCRIPTION
Additional "height: 100%;" is apparently necessary in .rightPanel for all screen sizes. The "important!" has been added as a precaution (not necessary for Chrome, but might be for other browsers).
