### PR TITLE
make fixed time intervals configurable via settings.js

### DIFF
--- a/src/main/js/controller/timeController.js
+++ b/src/main/js/controller/timeController.js
@@ -16,19 +16,7 @@
  */
 var TimeController = {
     currentTimespan: {},
-    timeRangeData: {
-        presets: [
-            {label: _('timeSelection.presets.today'), value: 'today'},
-            {label: _('timeSelection.presets.yesterday'), value: 'yesterday'},
-            {label: _('timeSelection.presets.todayYesterday'), value: 'today_yesterday'},
-            {label: _('timeSelection.presets.thisWeek'), value: 'thisWeek'},
-            {label: _('timeSelection.presets.lastWeek'), value: 'lastWeek'},
-            {label: _('timeSelection.presets.thisMonth'), value: 'thisMonth'},
-            {label: _('timeSelection.presets.lastMonth'), value: 'lastMonth'},
-            {label: _('timeSelection.presets.thisYear'), value: 'thisYear'},
-            {label: _('timeSelection.presets.lastYear'), value: 'lastYear'}
-        ]
-    },
+    timeRangeData: Settings.timeRangeData,
     init: function() {
         // get last save timespan
         this.currentTimespan = Status.get('timespan');
@@ -131,8 +119,15 @@ var TimeController = {
         this.getNearbyPeriode('add');
         this.updateTimeExtent();
     },
-    setPreset: function(type) {
-        this.currentTimespan = Time.isoTimespan(type);
+    setPreset: function(name) {
+        var interval;
+        $.each(this.timeRangeData.presets, function(idx,elem) {
+            if (elem.name === name) {
+                interval = this.interval;
+                return false;
+            }
+        });
+        this.currentTimespan = Time.isoTimespan(interval);
         this.updateTimeExtent();
         Modal.hide();
     },

--- a/src/main/js/helper/status.js
+++ b/src/main/js/helper/status.js
@@ -22,7 +22,7 @@ var Status = (function() {
                 'clusterStations': Settings.clusterStations,
                 'generalizeData': Settings.generalizeData,
                 'timeseries': {},
-                'timespan': Time.isoTimespan('today'),
+                'timespan': Time.isoTimespan(),
                 'saveStatus': Settings.saveStatus,
                 'concentrationMarker': Settings.concentrationMarker
             };

--- a/src/main/js/helper/time.js
+++ b/src/main/js/helper/time.js
@@ -15,59 +15,16 @@
  * limitations under the License.
  */
 var Time = {
-    isoTimespan: function(type) {
+    isoTimespan: function(interval) {
         /*
          * a) Start and end, such as "2007-03-01T13:00:00Z/2008-05-11T15:30:00Z"
          * b) Start and duration, such as "2007-03-01T13:00:00Z/P1Y2M10DT2H30M"
          * c) Duration and end, such as "P1Y2M10DT2H30M/2008-05-11T15:30:00Z"
          */
         // return obj: {from, till, mode}
-        var from = moment().startOf('day');
-        var till = moment().endOf('day');
-        var mode = null;
-
-        switch (type) {
-            case 'today':
-                from = from.startOf('day');
-                mode = 'day';
-                break;
-            case 'yesterday':
-                from = from.subtract('days', 1).startOf('day');
-                till = till.subtract('days', 1).endOf('day');
-                mode = 'day';
-                break;
-            case 'today_yesterday':
-                from = from.subtract('days', 1).startOf('day');
-                mode = 'day';
-                break;
-            case 'lastWeek':
-                from = from.subtract('weeks', 1).startOf('week');
-                till = till.subtract('weeks', 1).endOf('week');
-                mode = 'week';
-                break;
-            case 'thisWeek':
-                from = from.startOf('week');
-                mode = 'week';
-                break;
-            case 'lastMonth':
-                from = from.subtract('months', 1).startOf('month');
-                till = till.subtract('months', 1).endOf('month');
-                mode = 'month';
-                break;
-            case 'thisMonth':
-                from = from.startOf('month');
-                mode = 'month';
-                break;
-            case 'thisYear':
-                from = from.startOf('year');
-                mode = 'year';
-                break;
-            case 'lastYear':
-                from = from.subtract('years', 1).startOf('year');
-                till = till.subtract('years', 1).endOf('year');
-                mode = 'year';
-                break;
-        }
+        var from = (interval && interval.from) || moment().startOf('day');
+        var till = (interval && interval.till) || moment().endOf('day');
+        var mode = (interval && interval.mode) || 'day';
 
         return {
             'from': from,
@@ -78,9 +35,9 @@ var Time = {
     getRequestTimespan: function(from, till) {
         return moment(from).format() + '/' + moment(till).format();
     },
-    createTimespan: function(string) {
-        var timespan = string.split('/');
-        if (timespan.length == 2) {
+    createTimespan: function(interval) {
+        var timespan = interval.split('/');
+        if (timespan.length === 2) {
             var start = moment(timespan[0]);
             var end = moment(timespan[1]);
             if (start.isValid() && end.isValid()) {
@@ -91,7 +48,7 @@ var Time = {
                 };
             }
         }
-        return this.isoTimespan(string);
+        return this.isoTimespan(interval);
     },
     getFormatedTime: function(timestamp) {
         return moment(timestamp).format(Settings.dateformat);

--- a/src/main/js/i18n/de.js
+++ b/src/main/js/i18n/de.js
@@ -79,6 +79,7 @@ i18n.de = {
         header: 'Zeitraum',
         presetsHeader: 'Vordefiniert',
         presets: {
+            lastHour: 'letzte Stunde',
             today: 'heute',
             yesterday: 'gestern',
             todayYesterday: 'heute & gestern',

--- a/src/main/js/i18n/en.js
+++ b/src/main/js/i18n/en.js
@@ -79,6 +79,7 @@ i18n.en = {
         header: 'Time Range',
         presetsHeader: 'presets',
         presets: {
+            lastHour: 'last hour',
             today: 'today',
             yesterday: 'yesterday',
             todayYesterday: 'today & yesterday',

--- a/src/main/js/models/settings.js
+++ b/src/main/js/models/settings.js
@@ -31,7 +31,7 @@ var Settings = {
             apiUrl: 'http://sensorweb.demo.52north.org/sensorwebclient-webapp-stable/api/v1/'
         }
     ],
-    // A list of timeseries-API urls and an appropriate identifier to create internal timeseries ids 
+    // A list of timeseries-API urls and an appropriate identifier to create internal timeseries ids
     restApiUrls: {
 //		'http://192.168.1.135:8080/sensorwebclient-webapp/api/v1/' : 'localhost'
 //		'http://localhost:8090/sensorwebclient-webapp-3.3.0-SNAPSHOT/api/v1/' : 'localhost'
@@ -57,7 +57,7 @@ var Settings = {
     zoom: 13,
     // date/time format which is used on several places
     dateformat: 'DD.MM.YY HH:mmZ',
-    shortDateformat: "DD.MM.YY",
+    shortDateformat: 'DD.MM.YY',
     // duration after which latest values shall be ignored when rendering marker in the map
     ignoreAfterDuration: moment.duration(1, 'y'),
     // duration buffer for time series request
@@ -74,30 +74,124 @@ var Settings = {
     },
     // default language for i18n
     defaultLanguage: 'en',
-    // should saving the status be possible, 
+    // should saving the status be possible,
     saveStatusPossible: true,
     // entries on a page for the values table
     pagesize: 20,
     // line width for selected timeseries
     selectedLineWidth: 5,
     // common line width for unselected timeseries
-    commonLineWidth: 2, 
+    commonLineWidth: 2,
     // chart styling options see for more details: https://github.com/flot/flot/blob/master/API.md
     chartOptions: {},
-    // colorlist to select for a different timeseries color 
+    // colorlist to select for a different timeseries color
     colorList: ['#1abc9c', '#27ae60', '#2980b9', '#8e44ad', '#2c3e50', '#f1c40f',
         '#d35400', '#c0392b', '#7f8c8d'],
-    // interval to display the timeseries in a bar diagram with label and value in hours 
+    // interval to display the timeseries in a bar diagram with label and value in hours
     intervalList: [
         {label: _('styleChange.barChartInterval.hour'), value: 1},
         {label: _('styleChange.barChartInterval.day'), value: 24},
         {label: _('styleChange.barChartInterval.week'), value: 7 * 24},
         {label: _('styleChange.barChartInterval.month'), value: 30 * 24}
     ],
+    timeRangeData: {
+        presets: [
+            {
+                name: 'lastHour',
+                label: _('timeSelection.presets.lastHour'),
+                interval: {
+                    from: moment().subtract('hours', 1),
+                    till: moment(),
+                    mode: 'minutes'
+                }
+            },
+            {
+                name: 'today',
+                label: _('timeSelection.presets.today'),
+                interval: {
+                    from: moment().startOf('day'),
+                    till: moment().endOf('day'),
+                    mode: 'day'
+                }
+            },
+            {
+                name: 'yesterday',
+                label: _('timeSelection.presets.yesterday'),
+                interval: {
+                    from: moment().subtract('days', 1).startOf('day'),
+                    till: moment().subtract('days', 1).endOf('day'),
+                    mode: 'day'
+                }
+            },
+            {
+                name: 'todayYesterday',
+                label: _('timeSelection.presets.todayYesterday'),
+                interval: {
+                    from: moment().subtract('days', 1).startOf('day'),
+                    //till: moment(),
+                    mode: 'day'
+                }
+            },
+            {
+                name: 'thisWeek',
+                label: _('timeSelection.presets.thisWeek'),
+                interval: {
+                    from: moment().subtract('weeks', 1).startOf('week'),
+                    till: moment().subtract('weeks', 1).endOf('week'),
+                    mode: 'week'
+                }
+            },
+            {
+                name: 'lastWeek',
+                label: _('timeSelection.presets.lastWeek'),
+                interval: {
+                    from: moment().startOf('week'),
+                    //till: moment(),
+                    mode: 'week'
+                }
+            },
+            {
+                name: 'thisMonth',
+                label: _('timeSelection.presets.thisMonth'),
+                interval: {
+                    from: moment().subtract('months', 1).startOf('month'),
+                    till: moment().subtract('months', 1).endOf('month'),
+                    mode: 'month'
+                }
+            },
+            {
+                name: 'lastMonth',
+                label: _('timeSelection.presets.lastMonth'),
+                interval: {
+                    from: moment().startOf('month'),
+                    //till: moment(),
+                    mode: 'month'
+                }
+            },
+            {
+                name: 'thisYear',
+                label: _('timeSelection.presets.thisYear'),
+                interval: {
+                    from: moment().startOf('year'),
+                    //till: moment(),
+                    mode: 'year'
+                }
+            },
+            {
+                name: 'lastYear',
+                label: _('timeSelection.presets.lastYear'),
+                interval: {
+                    from: moment().subtract('years', 1).startOf('year'),
+                    till: moment().subtract('years', 1).endOf('year'),
+                    mode: 'year'
+                }
+            }
+        ]
+    },
     // configuration for the tile layer in the leaflet map (see for more information: http://leafletjs.com/reference.html#tilelayer )
     tileLayerUrl: 'http://{s}.tile.osm.org/{z}/{x}/{y}.png',
     tileLayerOptions: {
-        attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+        attribution: '&copy; <a href=http://osm.org/copyright>OpenStreetMap</a> contributors'
     },
     enableGeoSearch: true
 };

--- a/src/main/webapp/templates/time-range-settings.html
+++ b/src/main/webapp/templates/time-range-settings.html
@@ -18,7 +18,7 @@
                         <div class="panel-body">
                             {{#presets}}
                             <button class="btn btn-default multiline-button preset-btn"
-                                    data-preset-value="{{value}}">{{label}}</button>
+                                    data-preset-value="{{name}}">{{label}}</button>
                             {{/presets}}
                         </div>
                     </div>


### PR DESCRIPTION
This pull extracts creation of preset (resp. fixed) time intervals and makes them configurable via `settings.js`. When new interval is being added the following has to be specified:
- `name`: the name of the interval
-  `from`: start time of the interval
- `till`: end time of the interval
- `label`: an i18n key to enable translated text (to be added under `i18n/<languageCode>.js`

Use `moment()` to create time intervals dynamically, e.g.

``` javascript
{
    name: 'lastHour',
    label: _('timeSelection.presets.lastHour'),
    interval: {
        from: moment().subtract('hours', 1),
        till: moment(),
        mode: 'minutes'
    }
}
```
