### PR TITLE
The build fails if the project folder is not a GIT repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
                                 <!-- Faster to get just branch if skip = true -->
                                 <skip>false</skip>
                             </gitDescribe>
+                            <failOnNoGitDirectory>false</failOnNoGitDirectory>
                             <timestampFormat>{0,date,yyyy-MM-dd HH:mm:ss}</timestampFormat>
                         </configuration>
                     </execution>


### PR DESCRIPTION
e.g. if the project was downloaded as a Zip-File…
