### PR TITLE
Fixed minify build error

### DIFF
--- a/src/main/js/i18n/en_GB.js
+++ b/src/main/js/i18n/en_GB.js
@@ -21,7 +21,7 @@ i18n.en_GB = {
     settings: {
         permalink: {
             favorite: 'Status as favourite entry'
-        },
+        }
     },
     guide: {
         step13: {


### PR DESCRIPTION
```
Nov 10, 2014 12:29:39 PM com.google.javascript.jscomp.LoggerErrorManager println
SEVERE: jsc-0.2.0.js:382: ERROR - Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option.
        permalink: {
        ^
```
